### PR TITLE
Add staff ticket controls

### DIFF
--- a/src/buttons/close_ticket_.ts
+++ b/src/buttons/close_ticket_.ts
@@ -26,6 +26,11 @@ export default new ButtonCommand({
                 content:`Sorry, this ticket has to remain open for **${remainingTime > 60? Math.floor(remainingTime / 60) : Math.floor(remainingTime)}** more ${remainingTime > 60 ? `minute${Math.floor(remainingTime / 60) == 1 ? `` : `s`}` : `second${Math.floor(remainingTime) <= 1 ? `` : `s`}`} before it can be closed.`,
                 ephemeral:true
             })
+        if(supportThread.locked && supportThread.locked != interaction.user.id && !(currentUserId == supportThread.userId))
+            return interaction.reply({
+                content:`This ticket's management has been restricted to <@${supportThread.locked}>. Please contact them to perform this action.`,
+                ephemeral:true
+            })
         interaction.reply({
             content:`<#${threadChannelId}> will be locked soon.`,
             ephemeral:true

--- a/src/buttons/open_private_ticket.ts
+++ b/src/buttons/open_private_ticket.ts
@@ -61,13 +61,20 @@ export default new ButtonCommand({
                   {
                       "type":1,
                         "components":[
-                            {
-                                "type":2,
-                                "style":2,
-                                "customId":`close_ticket_${threadStarter}`,
-                                "label":"Close Ticket",
-                                "emoji":"🔒"
-                            }
+                          {
+                            "type":2,
+                            "style":2,
+                            "customId":`close_ticket_${threadStarter}`,
+                            "label":"Close Ticket",
+                            "emoji":"🔒"
+                          },
+                          {
+                            "type":"BUTTON",
+                            "style":"SECONDARY",
+                            "customId":`staff_controls_${threadStarter}`,
+                            "label":"Staff Controls",
+                            "emoji":"🛠"
+                          }
                         ]
                     }
                 ]

--- a/src/buttons/open_ticket.ts
+++ b/src/buttons/open_ticket.ts
@@ -71,8 +71,8 @@ export default new ButtonCommand({
                 {
                   "type":"BUTTON",
                   "style":"SECONDARY",
-                  "customId":`switch_ticket_type_${threadStarter}`,
-                  "label":"Switch to Private Ticket"
+                  "customId":`staff_controls_${threadStarter}`,
+                  "label":"Staff Controls"
                 }
               ]
             }

--- a/src/buttons/open_ticket.ts
+++ b/src/buttons/open_ticket.ts
@@ -72,7 +72,8 @@ export default new ButtonCommand({
                   "type":"BUTTON",
                   "style":"SECONDARY",
                   "customId":`staff_controls_${threadStarter}`,
-                  "label":"Staff Controls"
+                  "label":"Staff Controls",
+                  "emoji":"🛠"
                 }
               ]
             }

--- a/src/buttons/private_ticket_staff_controls.ts
+++ b/src/buttons/private_ticket_staff_controls.ts
@@ -1,0 +1,129 @@
+import { BaseMessageComponentOptions, MessageActionRow, MessageActionRowOptions, MessageEmbed, OverwriteResolvable, TextChannel } from "discord.js";
+import { config } from "../../config";
+import ButtonCommand from "../classes/ButtonCommand";
+
+const userPingReplaceRegExp = new RegExp(/\!{(USER_PING)\}!/, "g");
+
+export default new ButtonCommand({
+  customId:"private_ticket_staff_controls",
+  checkType:"STARTS_WITH",
+  staffOnly:true,
+  async execute(interaction){
+      if(!interaction.channel.isText())
+        return interaction.reply({
+            content:`This is only for text channels`,
+            ephemeral:true
+        })
+    let thisChannel:TextChannel = interaction.guild.channels.cache.get(interaction.channelId) as TextChannel;
+    let threadStarter = interaction.customId.split("private_ticket_staff_controls_")[1];
+    let randomChars = (Math.random() + 1).toString(36).substring(7).toString();
+
+    let components:(MessageActionRow | (Required<BaseMessageComponentOptions> & MessageActionRowOptions))[] = [
+        {
+            type:"ACTION_ROW",
+            components:[
+                {
+                    "type":"BUTTON",
+                    "style":"SECONDARY",
+                    "customId":`collecter_${randomChars}_lock_channel-${interaction.message?.id}`,
+                    "label":`Archive Channel`,
+                    "disabled":thisChannel.permissionOverwrites.cache.find(po => po.id == thisChannel.guildId && po.deny.has("SEND_MESSAGES"))?true:false
+                }
+            ]
+        }
+    ];
+
+    interaction.reply({
+        content:`**Staff Private Ticket Controls**`,
+        components,
+        ephemeral:true
+    })
+
+
+    let collector = interaction.channel.createMessageComponentCollector({
+        componentType:"BUTTON",
+        message:await interaction.fetchReply(),
+        time:300000,
+        filter(button){
+            return button.user.id == interaction.user.id && button.customId.startsWith(`collecter_${randomChars}`)
+        }
+    })
+
+    collector.on("collect", async (collected) => {
+        if(!collected) return;
+        let starterMessageId = collected.customId.split("-")[1];
+        
+        // Archive
+        if(collected.customId.includes("lock_channel")){
+            let thisChannel:TextChannel = interaction.guild.channels.cache.get(collected.channelId) as TextChannel;
+
+            if(thisChannel.isText()){
+                let staffOverrides:OverwriteResolvable[] = config.staffRoles.map((roleId) => {
+                    return {
+                        type:"role",
+                        allow:["VIEW_CHANNEL", "READ_MESSAGE_HISTORY"],
+                        deny:["SEND_MESSAGES", "ADD_REACTIONS"],
+                        id:roleId
+                    }
+                })
+
+                let embeds:MessageEmbed[] = [
+                    new MessageEmbed(                {
+                        "description":`🔒 Private Ticket Channel has been closed by <@${interaction.user.id}>`,
+                        "color":16711680
+                    })
+                ];
+                if(config.closingTicketsSettings?.closeMessage)
+                    embeds.push(new MessageEmbed({
+                        "description":config.closingTicketsSettings.closeMessage.replace(userPingReplaceRegExp, `<@${threadStarter}>`),
+                        "footer":{
+                            text:"The message above is set by the server"
+                        }
+                    }));
+                
+                await interaction.channel.send({embeds})
+
+
+                let res = await thisChannel.permissionOverwrites.set([
+                    ...staffOverrides,
+                    {
+                        type:"role",
+                        id:interaction.guildId,
+                        deny:["VIEW_CHANNEL", "SEND_MESSAGES", "ADD_REACTIONS"]
+                    },
+                    {
+                        type:"member",
+                        id:interaction.client.user.id,
+                        allow:["VIEW_CHANNEL", "SEND_MESSAGES", "READ_MESSAGE_HISTORY", "ATTACH_FILES", "EMBED_LINKS", "MANAGE_MESSAGES", "MANAGE_CHANNELS"]
+                    }
+                ]);
+
+                if(!res){
+                    collected.update({
+                        embeds:[
+                            {
+                                description:`Failed to archive channel.`,
+                                color:"RED"
+                            }
+                        ]
+                    })
+                }
+                if(res){
+                    components[0].components[0].disabled = true;
+                    await interaction.channel.messages.cache.get(starterMessageId)
+                    collected.update({
+                        components,
+                        embeds:[
+                            {
+                                description:`Successfully archived channel.`,
+                                color:"GREEN"
+                            }
+                        ]
+                    })
+                }
+            }
+            return;
+        }
+    })
+  }
+})

--- a/src/buttons/private_ticket_staff_controls.ts
+++ b/src/buttons/private_ticket_staff_controls.ts
@@ -28,6 +28,13 @@ export default new ButtonCommand({
                     "customId":`collecter_${randomChars}_lock_channel-${interaction.message?.id}`,
                     "label":`Archive Channel`,
                     "disabled":thisChannel.permissionOverwrites.cache.find(po => po.id == thisChannel.guildId && po.deny.has("SEND_MESSAGES"))?true:false
+                },
+                {
+                    "type":"BUTTON",
+                    "style":"DANGER",
+                    "customId":`collecter_${randomChars}_delete_channel-${interaction.message?.id}`,
+                    "label":`Delete Channel`,
+                    "disabled":!interaction.memberPermissions.has("MANAGE_CHANNELS") || !interaction.guild.me.permissions.has("MANAGE_CHANNELS")?true:false
                 }
             ]
         }
@@ -123,6 +130,10 @@ export default new ButtonCommand({
                 }
             }
             return;
+        }
+
+        if(collected.customId.includes("delete_channel")){
+            await collected.channel.delete()
         }
     })
   }

--- a/src/buttons/staff_controls.ts
+++ b/src/buttons/staff_controls.ts
@@ -1,0 +1,144 @@
+import { ThreadChannel } from "discord.js";
+import { config } from "../../config";
+import { TicketType } from "../../typings";
+import ButtonCommand from "../classes/ButtonCommand";
+
+export default new ButtonCommand({
+  customId:"staff_controls",
+  checkType:"STARTS_WITH",
+  staffOnly:true,
+  async execute(interaction){
+    let threadStarter = interaction.customId.split("staff_controls_")[1];
+    let threadData = interaction.client.getSupportThreadData(threadStarter);
+    let randomChars = (Math.random() + 1).toString(36).substring(7).toString();
+
+    interaction.reply({
+        content:`**Staff Ticket Controls**`,
+        components:[
+            {
+                type:"ACTION_ROW",
+                components:[
+                    {
+                        "type":"BUTTON",
+                        "style":"SECONDARY",
+                        "customId":`collecter_${randomChars}_switch_ticket_type-${interaction.message?.id}`,
+                        "label":`Toggle Ticket Type`
+                    },
+                    {
+                        "type":"BUTTON",
+                        "style":"SECONDARY",
+                        "customId":`collecter_${randomChars}_toggle_restricted_ticket-${interaction.message?.id}`,
+                        "label":`Toggle Restricted Management to ${interaction.user.tag}`
+                    }
+                ]
+            }
+        ],
+        ephemeral:true
+    })
+
+
+    let collector = interaction.channel.createMessageComponentCollector({
+        componentType:"BUTTON",
+        message:await interaction.fetchReply(),
+        time:300000,
+        filter(button){
+            return button.user.id == interaction.user.id && button.customId.startsWith(`collecter_${randomChars}`)
+        }
+    })
+
+    collector.on("collect", async (collected) => {
+        if(!collected) return;
+        let staffControlsMessageInteraction = collected;
+        let starterMessageId = staffControlsMessageInteraction.customId.split("-")[1];
+        let threadData = interaction.client.getSupportThreadData(threadStarter);
+        
+        // Switch to Public/Private ticket
+        if(staffControlsMessageInteraction.customId.includes("switch_ticket_type")){
+            let newType:TicketType;
+            if(threadData.type == "PUBLIC")
+                newType = "PRIVATE";
+            if(threadData.type == "PRIVATE")
+                newType = "PUBLIC";
+            
+            let res = await interaction.client.updateSupportThread({
+                newType,
+                userId:threadData.userId,
+                threadId:threadData.threadChannelId
+            })
+            if(res === false){
+                staffControlsMessageInteraction.update({
+                    embeds:[
+                        {
+                            description:`Failed to update support thread data. Failed to change ticket type to ${newType == 'PUBLIC' ? "Public" : "Private"}.`,
+                            color:"RED"
+                        }
+                    ]
+                })
+            }
+            if(res == true){
+                staffControlsMessageInteraction.update({
+                    embeds:[
+                        {
+                            description:`Successfully changed ticket type to ${newType == 'PUBLIC' ? "Public" : "Private"}.`,
+                            color:"GREEN"
+                        }
+                    ]
+                })
+                interaction.channel.messages.cache.get(starterMessageId)?.edit({
+                    content:interaction.message.content.replace(newType == "PUBLIC"?":lock: *This is a private ticket, so only staff may reply.*":":unlock: *This is a public ticket, everyone may view and reply to it..*", newType == "PRIVATE"?":lock: *This is a private ticket, so only staff may reply.*":":unlock: *This is a public ticket, everyone may view and reply to it..*")
+                })
+                interaction.channel?.send({
+                    embeds:[
+                        {
+                            description:`${newType == "PUBLIC" ? ":unlock:" : ":lock:"} Ticket has been switched to a ${newType == 'PUBLIC' ? "Public" : "Private"} Ticket.`,
+                            color:newType == "PUBLIC" ? "GREEN" : "RED",
+                            footer:{
+                                iconURL:`https://cdn.discordapp.com/avatars/${interaction.member?.user.id}/${interaction.member?.user.avatar}${interaction.member?.user.avatar.startsWith("a_")?".gif":".png"}`,
+                                text:`${interaction.member?.user.username}#${interaction.member?.user.discriminator}`
+                            }
+                        }
+                    ]
+                })
+            }
+            return;
+        }
+
+        // Lock Ticket Management
+        if(staffControlsMessageInteraction.customId.includes("toggle_restricted_ticket")){
+            let locked: string | undefined;
+            if(typeof threadData.locked == 'undefined')
+                locked = staffControlsMessageInteraction.user?.id;
+            if(typeof threadData.locked == 'string')
+                locked = undefined;
+            console.log("old", threadData.locked)
+            console.log("new", locked)
+            let res = await interaction.client.updateSupportThread({
+                userId:threadData.userId,
+                threadId:threadData.threadChannelId,
+                locked
+            })
+            if(res === false){
+                staffControlsMessageInteraction.update({
+                    embeds:[
+                        {
+                            description:`Failed to update support thread data. Failed to ${typeof locked == 'string'?'restrict':'unrestrict'} ticket management ${typeof locked == 'string'?'to':'from'} ${interaction.user?.tag}.`,
+                            color:"RED"
+                        }
+                    ]
+                })
+            }
+            if(res == true){
+                staffControlsMessageInteraction.update({
+                    embeds:[
+                        {
+                            description:`Successfully ${typeof locked == 'string'?'restricted':'unrestricted'} ticket management ${typeof locked == 'string'?'to':'from'} ${interaction.user?.tag}.`,
+                            color:"GREEN"
+                        }
+                    ]
+                })
+            }
+            return;
+        }
+    })
+  }
+})

--- a/src/commands/closeprompt.ts
+++ b/src/commands/closeprompt.ts
@@ -24,6 +24,11 @@ export default new Command({
                 content:`This command must be sent in the ticket channel`,
                 ephemeral:true
             })
+        if(ticket.locked && ticket.locked != interaction.user.id)
+            return interaction.reply({
+                content:`This ticket's management has been restricted to <@${ticket.locked}>. Please contact them to perform this action.`,
+                ephemeral:true
+            })
         interaction.reply({
             content:`Hey <@${user.id}>,\n\n<@${interaction.user.id}> has requested that this ticket be closed. If you're done with your question, you can close it with the button below. If you are not finished, please let us know so we don't close your ticket for inactivity.`,
             components:[

--- a/src/commands/closeticket.ts
+++ b/src/commands/closeticket.ts
@@ -28,6 +28,11 @@ export default new Command({
                 content:`You can't close a ticket that isn't yours.`,
                 ephemeral:true
             })
+        if(supportThread.locked && supportThread.locked != interaction.user.id)
+            return interaction.reply({
+                content:`This ticket's management has been restricted to <@${supportThread.locked}>. Please contact them to perform this action.`,
+                ephemeral:true
+            })
         if(config.closingTicketsSettings?.ticketsMinimumAge > secondsSinceCreation && !isStaff)
             return interaction.reply({
                 content:`Sorry, this ticket has to remain open for **${remainingTime > 60? Math.floor(remainingTime / 60) : Math.floor(remainingTime)}** more ${remainingTime > 60 ? `minute${Math.floor(remainingTime / 60) == 1 ? `` : `s`}` : `second${Math.floor(remainingTime) <= 1 ? `` : `s`}`} before it can be closed.`,

--- a/src/commands/eta.ts
+++ b/src/commands/eta.ts
@@ -18,9 +18,12 @@ export default new Command({
             "when deepsea becomes a cake",
             "when daniel is banned",
             "when daniel become good programmer",
+            "when daniel gets a good computer",
+            "when daniel plays good games",
+            "when daniel stops making unstable bots",
             "when hax stops playing apex",
             "when hax stops golfing",
-            "when hax finally [explains](https://cdn.discordapp.com/attachments/744457183843844147/934593115623419904/unknown.png)"
+            "when hax finally [explains](https://cdn.discordapp.com/attachments/744457183843844147/934593115623419904/unknown.png) his message from <t:1606257486:R>"
         ]
         const index = Math.floor(Math.random() * messages.length)
         const msg = messages[index]

--- a/src/commands/ticket.ts
+++ b/src/commands/ticket.ts
@@ -71,8 +71,9 @@ export default new Command({
                     {
                       "type":"BUTTON",
                       "style":"SECONDARY",
-                      "customId":`switch_ticket_type_${threadStarter}`,
-                      "label":`Switch to ${supportRoleOnly?"Public":"Private"} Ticket`
+                      "customId":`staff_controls_${threadStarter}`,
+                      "label":"Staff Controls",
+                      "emoji":"🛠"
                     }
                   ]
                 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,11 +72,16 @@ client.createSupportThread = async (options:{shortDesc:string, userId:string, pr
 	return createdChannel;
 }
 
-client.updateSupportThread = async (options:{userId:string, threadId:string, newType?:TicketType, newName?:string}) => {
+client.updateSupportThread = async (options:{userId:string, threadId:string, newType?:TicketType, newName?:string, locked?:string}) => {
 	if(!publicThreads[options.threadId] && !privateThreads[options.threadId])
 		return false;
 	let threadChannel = client.channels.cache.get(options.threadId) as ThreadChannel;
 	let newThreadChannelName:string = threadChannel.name;
+	
+	if(typeof options.locked == 'undefined' && options.locked === undefined || typeof options.locked == 'string'){
+		activeTickets[options.userId].locked = options.locked;
+		saveActiveTicketsData()
+	}
 
 	if(options.newType){
 		activeTickets[options.userId].type = options.newType;

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ client.createSupportThread = async (options:{shortDesc:string, userId:string, pr
 	return createdChannel;
 }
 
-client.updateSupportThread = async (options:{userId:string, threadId:string, newType?:TicketType, newName?:string, locked?:string}) => {
+client.updateSupportThread = async (options:{userId:string, threadId:string, newType?:TicketType, newName?:string, locked?:string, externalChannelId?:string}) => {
 	if(!publicThreads[options.threadId] && !privateThreads[options.threadId])
 		return false;
 	let threadChannel = client.channels.cache.get(options.threadId) as ThreadChannel;
@@ -80,6 +80,11 @@ client.updateSupportThread = async (options:{userId:string, threadId:string, new
 	
 	if(typeof options.locked == 'undefined' && options.locked === undefined || typeof options.locked == 'string'){
 		activeTickets[options.userId].locked = options.locked;
+		saveActiveTicketsData()
+	}
+
+	if(typeof options.externalChannelId == 'undefined' && options.externalChannelId === undefined || typeof options.externalChannelId == 'string'){
+		activeTickets[options.userId].externalChannelId = options.externalChannelId;
 		saveActiveTicketsData()
 	}
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -96,7 +96,7 @@ declare module 'discord.js' {
         privateTicket:boolean
       }):Promise<ThreadChannel>
       getSupportThreadData(userId:string):ActiveTicketsData
-      updateSupportThread(options:{userId:string, threadId:string, newType?:TicketType, newName?:string, locked?:string}):Promise<boolean>
+      updateSupportThread(options:{userId:string, threadId:string, newType?:TicketType, newName?:string, locked?:string, externalChannelId?:string}):Promise<boolean>
       closeSupportThread(options:{
         userId:string,
         channelId?:string,
@@ -135,6 +135,8 @@ interface ActiveTicketsData {
   type:TicketType,
   /** Either not present or User ID */
   locked?:string
+  /** Either not present or Channel ID */
+  externalChannelId?:string
 }
 
 interface ActiveTickets {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -96,7 +96,7 @@ declare module 'discord.js' {
         privateTicket:boolean
       }):Promise<ThreadChannel>
       getSupportThreadData(userId:string):ActiveTicketsData
-      updateSupportThread(options:{userId:string, threadId:string, newType?:TicketType, newName?:string}):Promise<boolean>
+      updateSupportThread(options:{userId:string, threadId:string, newType?:TicketType, newName?:string, locked?:string}):Promise<boolean>
       closeSupportThread(options:{
         userId:string,
         channelId?:string,
@@ -132,7 +132,9 @@ interface ActiveTicketsData {
   userId:string,
   active:boolean,
   createdMs:number,
-  type:TicketType
+  type:TicketType,
+  /** Either not present or User ID */
+  locked?:string
 }
 
 interface ActiveTickets {


### PR DESCRIPTION
This PR adds staff ticket controls to Support Tickets. 
<img width="322" alt="image" src="https://user-images.githubusercontent.com/46201432/153725668-5fb43837-3ca0-44ae-be9b-d5a0a3132b5a.png">
<img width="715" alt="image" src="https://user-images.githubusercontent.com/46201432/153725675-a9e85339-e2d9-43d4-8004-051adb3c7c6e.png">
