### PR TITLE
Support tickets modals

### DIFF
--- a/src/buttons/close_ticket_.ts
+++ b/src/buttons/close_ticket_.ts
@@ -26,6 +26,11 @@ export default new ButtonCommand({
                 content:`Sorry, this ticket has to remain open for **${remainingTime > 60? Math.floor(remainingTime / 60) : Math.floor(remainingTime)}** more ${remainingTime > 60 ? `minute${Math.floor(remainingTime / 60) == 1 ? `` : `s`}` : `second${Math.floor(remainingTime) <= 1 ? `` : `s`}`} before it can be closed.`,
                 ephemeral:true
             })
+        if(supportThread.locked && supportThread.locked != interaction.user.id && !(currentUserId == supportThread.userId))
+            return interaction.reply({
+                content:`This ticket's management has been restricted to <@${supportThread.locked}>. Please contact them to perform this action.`,
+                ephemeral:true
+            })
         interaction.reply({
             content:`<#${threadChannelId}> will be locked soon.`,
             ephemeral:true

--- a/src/buttons/close_ticket_.ts
+++ b/src/buttons/close_ticket_.ts
@@ -47,7 +47,7 @@ export default new ButtonCommand({
                                     custom_id: 'feedback_content',
                                     style: 2,
                                     label: 'How was your experience in the ticket?',
-                                    placeholder: 'This is shared with the server admin',
+                                    placeholder: 'This is shared with the server admin(s)',
                                     min_length:10,
                                     required:false
                                 }

--- a/src/buttons/open_private_ticket.ts
+++ b/src/buttons/open_private_ticket.ts
@@ -61,13 +61,20 @@ export default new ButtonCommand({
                   {
                       "type":1,
                         "components":[
-                            {
-                                "type":2,
-                                "style":2,
-                                "customId":`close_ticket_${threadStarter}`,
-                                "label":"Close Ticket",
-                                "emoji":"🔒"
-                            }
+                          {
+                            "type":2,
+                            "style":2,
+                            "customId":`close_ticket_${threadStarter}`,
+                            "label":"Close Ticket",
+                            "emoji":"🔒"
+                          },
+                          {
+                            "type":"BUTTON",
+                            "style":"SECONDARY",
+                            "customId":`staff_controls_${threadStarter}`,
+                            "label":"Staff Controls",
+                            "emoji":"🛠"
+                          }
                         ]
                     }
                 ]

--- a/src/buttons/open_ticket.ts
+++ b/src/buttons/open_ticket.ts
@@ -31,8 +31,7 @@ export default new ButtonCommand({
                   custom_id: 'question1',
                   style: 1,
                   label: 'Firmware + Atmosphere / DeepSea version',
-                  placeholder: 'FW 13.2.1, Atmosphere 1.2.6, DeepSea 3.5.0',
-                  min_length:12,
+                  placeholder: 'FW X.X.X, Atmosphere X.X.X, DeepSea X.X.X',
                   max_length:50
                 }
               ]
@@ -44,8 +43,8 @@ export default new ButtonCommand({
                   type: 4,
                   custom_id: 'question2',
                   style: 1,
-                  label: 'Do you use Hekate or Fusee-Primary?',
-                  placeholder: 'Hekate / Fusee Primary',
+                  label: 'Do you use Hekate or Fusee?',
+                  placeholder: 'Hekate / Fusee',
                   min_length:5,
                   max_length:50
                 }
@@ -58,10 +57,8 @@ export default new ButtonCommand({
                   type: 4,
                   custom_id: 'question3',
                   style: 1,
-                  label: 'Do you have an error code/screen?',
-                  placeholder: 'Error Code 0000-0000 / Send screenshot when ticket opened',
-                  min_length:8,
-                  max_length:50,
+                  label: 'Do you have an error code and screen?',
+                  placeholder: 'Error Code 0000-0000 / Screenshot link',
                   required:false
                 }
               ]
@@ -74,7 +71,7 @@ export default new ButtonCommand({
                   custom_id: 'question4',
                   style: 1,
                   label: 'Coming for support with SDSetup or DeepSea?',
-                  placeholder: 'SDSetup / DeepSea / Other',
+                  placeholder: 'SDSetup / DeepSea / Something else',
                   max_length:50
                 }
               ]

--- a/src/buttons/open_ticket.ts
+++ b/src/buttons/open_ticket.ts
@@ -71,8 +71,8 @@ export default new ButtonCommand({
                 {
                   "type":"BUTTON",
                   "style":"SECONDARY",
-                  "customId":`switch_ticket_type_${threadStarter}`,
-                  "label":"Switch to Private Ticket"
+                  "customId":`staff_controls_${threadStarter}`,
+                  "label":"Staff Controls"
                 }
               ]
             }

--- a/src/buttons/open_ticket.ts
+++ b/src/buttons/open_ticket.ts
@@ -17,88 +17,88 @@ export default new ButtonCommand({
         content:`Topic must be 1-90 characters`,
         ephemeral:true
       })
-    interaction.deferReply({ephemeral:true}).then(() => {
-      let currentThread = interaction.client.getSupportThreadData(threadStarter);
-      if(currentThread?.active || false)
-        return interaction.followUp({
-          content:`You already have a ticket opened. Please use your current ticket or close your current ticket to open a new one.`,
-          components:[
+    // @ts-ignore
+    interaction.client.api.interactions(interaction.id)(interaction.token).callback.post({
+      data:{
+        type: 9,
+        data: {
+          components: [
             {
-              type:"ACTION_ROW",
+              type: 1,
+              components: [
+                {
+                  type: 4,
+                  custom_id: 'question1',
+                  style: 1,
+                  label: 'Firmware + Atmosphere / DeepSea version',
+                  placeholder: 'FW 13.2.1, Atmosphere 1.2.6, DeepSea 3.5.0',
+                  min_length:12,
+                  max_length:50
+                }
+              ]
+            },
+            {
+              type: 1,
               components:[
                 {
-                  type:"BUTTON",
-                  label:"View Current Ticket",
-                  style:"LINK",
-                  url:`https://discord.com/channels/${interaction.guildId}/${currentThread?.threadChannelId}`
-                },
-                {
-                  type:"BUTTON",
-                  label:"Close Current Ticket",
-                  style:"DANGER",
-                  customId:`close_ticket_${threadStarter}`
+                  type: 4,
+                  custom_id: 'question2',
+                  style: 1,
+                  label: 'Do you use Hekate or Fusee-Primary?',
+                  placeholder: 'Hekate / Fusee Primary',
+                  min_length:5,
+                  max_length:50
                 }
               ]
-            }
-          ]
-        })
-      interaction.client.createSupportThread({
-        shortDesc:topic.value.toString(), 
-        userId:threadStarter, 
-        privateTicket: supportRoleOnly
-      })
-      .then(channel => {                
-        const questions = [
-          `- Firmware and CFW / Atmosphere / DeepSea version`,
-          `- Do you use hekate or fusee-primary?`,
-          `- If you have an error screen with ID or code, what does it say? A screenshot/picture could be helpful.`,
-          `- What, if anything, have you tried to fix the issue?`,
-          `- Are you coming for support with SDSetup or DeepSea?`
-        ];
-        (interaction.client.channels.cache.get(channel.id) as ThreadChannel).send({
-          "content":`${supportRoleOnly?"\n:lock: *This is a private ticket, so only staff may reply.*":"\n:unlock: *This is a public ticket, everyone may view and reply to it..*"}\n\nHey <@${threadStarter}>, to make it easier for us and others help you with your issue, please tell us a few things about your setup, like:\n\n${questions.join("\n")}`,
-          "components":[
+            },
             {
-              "type":1,
-              "components":[
+              type: 1,
+              components:[
                 {
-                  "type":2,
-                  "style":2,
-                  "customId":`close_ticket_${threadStarter}`,
-                  "label":"Close Ticket",
-                  "emoji":"🔒"
-                },
+                  type: 4,
+                  custom_id: 'question3',
+                  style: 1,
+                  label: 'Do you have an error code/screen?',
+                  placeholder: 'Error Code 0000-0000 / Send screenshot when ticket opened',
+                  min_length:8,
+                  max_length:50,
+                  required:false
+                }
+              ]
+            },
+            {
+              type: 1,
+              components:[
                 {
-                  "type":"BUTTON",
-                  "style":"SECONDARY",
-                  "customId":`staff_controls_${threadStarter}`,
-                  "label":"Staff Controls",
-                  "emoji":"🛠"
+                  type: 4,
+                  custom_id: 'question4',
+                  style: 1,
+                  label: 'Coming for support with SDSetup or DeepSea?',
+                  placeholder: 'SDSetup / DeepSea / Other',
+                  max_length:50
+                }
+              ]
+            },
+            {
+              type: 1,
+              components:[
+                {
+                  type: 4,
+                  custom_id: 'question5',
+                  style: 2,
+                  label: 'Describe your issue and what led up to it',
+                  placeholder: 'Well, I was playing Splatoon 2 until...',
+                  min_length:20
                 }
               ]
             }
-          ]
-        }).then(r => {
-          r.channel.awaitMessages({
-            max:1,
-            filter(message){
-              return message.author.id == threadStarter;
-            }
-          }).then(async () => {
-            await interaction.client.updateSupportThread({
-              threadId:channel.id,
-              userId:threadStarter
-            });
-            (interaction.client.channels.cache.get(channel.id) as ThreadChannel).send({
-              "content":`Thanks! <@&${config.supportRoleId}> will be here to support you shortly.\n\n*(Disclaimer: You may not receive an answer instantly. Many of us have lives outside of Discord and will respond whenever we're able to, whenever that is.)*`
-            })
-          })
-          interaction.followUp({
-            content:`Ticket is ready in <#${channel.id}>`,
-            ephemeral:true
-          })
-        })
-      })
-    })
+          ],
+          title: 'Open Support Ticket',
+          custom_id: 'open_ticket_modal'
+        }
+      }
+    }).then((err) => {
+      console.log(err)
+    });
   }
 })

--- a/src/buttons/open_ticket.ts
+++ b/src/buttons/open_ticket.ts
@@ -72,7 +72,8 @@ export default new ButtonCommand({
                   "type":"BUTTON",
                   "style":"SECONDARY",
                   "customId":`staff_controls_${threadStarter}`,
-                  "label":"Staff Controls"
+                  "label":"Staff Controls",
+                  "emoji":"🛠"
                 }
               ]
             }

--- a/src/buttons/open_ticket_prompt.ts
+++ b/src/buttons/open_ticket_prompt.ts
@@ -5,6 +5,31 @@ export default new ButtonCommand({
   customId:"open_ticket_prompt",
   checkType:"EQUALS",
   execute(interaction){
+    let threadStarter = interaction.member.user.id;
+    let currentThread = interaction.client.getSupportThreadData(threadStarter);
+    if(currentThread?.active || false)
+      return interaction.followUp({
+        content:`You already have a ticket opened. Please use your current ticket or close your current ticket to open a new one.`,
+        components:[
+          {
+            type:"ACTION_ROW",
+            components:[
+              {
+                type:"BUTTON",
+                label:"View Current Ticket",
+                style:"LINK",
+                url:`https://discord.com/channels/${interaction.guildId}/${currentThread?.threadChannelId}`
+              },
+              {
+                type:"BUTTON",
+                label:"Close Current Ticket",
+                style:"DANGER",
+                customId:`close_ticket_${threadStarter}`
+              }
+            ]
+          }
+        ]
+      })
     if(config.openingTicketPrompt?.enabled){
       return interaction.reply({
         content:config.openingTicketPrompt.message,

--- a/src/buttons/open_ticket_prompt.ts
+++ b/src/buttons/open_ticket_prompt.ts
@@ -8,7 +8,7 @@ export default new ButtonCommand({
     let threadStarter = interaction.member.user.id;
     let currentThread = interaction.client.getSupportThreadData(threadStarter);
     if(currentThread?.active || false)
-      return interaction.followUp({
+      return interaction.reply({
         content:`You already have a ticket opened. Please use your current ticket or close your current ticket to open a new one.`,
         components:[
           {
@@ -28,7 +28,8 @@ export default new ButtonCommand({
               }
             ]
           }
-        ]
+        ],
+        ephemeral:true
       })
     if(config.openingTicketPrompt?.enabled){
       return interaction.reply({

--- a/src/buttons/private_ticket_staff_controls.ts
+++ b/src/buttons/private_ticket_staff_controls.ts
@@ -1,0 +1,129 @@
+import { BaseMessageComponentOptions, MessageActionRow, MessageActionRowOptions, MessageEmbed, OverwriteResolvable, TextChannel } from "discord.js";
+import { config } from "../../config";
+import ButtonCommand from "../classes/ButtonCommand";
+
+const userPingReplaceRegExp = new RegExp(/\!{(USER_PING)\}!/, "g");
+
+export default new ButtonCommand({
+  customId:"private_ticket_staff_controls",
+  checkType:"STARTS_WITH",
+  staffOnly:true,
+  async execute(interaction){
+      if(!interaction.channel.isText())
+        return interaction.reply({
+            content:`This is only for text channels`,
+            ephemeral:true
+        })
+    let thisChannel:TextChannel = interaction.guild.channels.cache.get(interaction.channelId) as TextChannel;
+    let threadStarter = interaction.customId.split("private_ticket_staff_controls_")[1];
+    let randomChars = (Math.random() + 1).toString(36).substring(7).toString();
+
+    let components:(MessageActionRow | (Required<BaseMessageComponentOptions> & MessageActionRowOptions))[] = [
+        {
+            type:"ACTION_ROW",
+            components:[
+                {
+                    "type":"BUTTON",
+                    "style":"SECONDARY",
+                    "customId":`collecter_${randomChars}_lock_channel-${interaction.message?.id}`,
+                    "label":`Archive Channel`,
+                    "disabled":thisChannel.permissionOverwrites.cache.find(po => po.id == thisChannel.guildId && po.deny.has("SEND_MESSAGES"))?true:false
+                }
+            ]
+        }
+    ];
+
+    interaction.reply({
+        content:`**Staff Private Ticket Controls**`,
+        components,
+        ephemeral:true
+    })
+
+
+    let collector = interaction.channel.createMessageComponentCollector({
+        componentType:"BUTTON",
+        message:await interaction.fetchReply(),
+        time:300000,
+        filter(button){
+            return button.user.id == interaction.user.id && button.customId.startsWith(`collecter_${randomChars}`)
+        }
+    })
+
+    collector.on("collect", async (collected) => {
+        if(!collected) return;
+        let starterMessageId = collected.customId.split("-")[1];
+        
+        // Archive
+        if(collected.customId.includes("lock_channel")){
+            let thisChannel:TextChannel = interaction.guild.channels.cache.get(collected.channelId) as TextChannel;
+
+            if(thisChannel.isText()){
+                let staffOverrides:OverwriteResolvable[] = config.staffRoles.map((roleId) => {
+                    return {
+                        type:"role",
+                        allow:["VIEW_CHANNEL", "READ_MESSAGE_HISTORY"],
+                        deny:["SEND_MESSAGES", "ADD_REACTIONS"],
+                        id:roleId
+                    }
+                })
+
+                let embeds:MessageEmbed[] = [
+                    new MessageEmbed(                {
+                        "description":`🔒 Private Ticket Channel has been closed by <@${interaction.user.id}>`,
+                        "color":16711680
+                    })
+                ];
+                if(config.closingTicketsSettings?.closeMessage)
+                    embeds.push(new MessageEmbed({
+                        "description":config.closingTicketsSettings.closeMessage.replace(userPingReplaceRegExp, `<@${threadStarter}>`),
+                        "footer":{
+                            text:"The message above is set by the server"
+                        }
+                    }));
+                
+                await interaction.channel.send({embeds})
+
+
+                let res = await thisChannel.permissionOverwrites.set([
+                    ...staffOverrides,
+                    {
+                        type:"role",
+                        id:interaction.guildId,
+                        deny:["VIEW_CHANNEL", "SEND_MESSAGES", "ADD_REACTIONS"]
+                    },
+                    {
+                        type:"member",
+                        id:interaction.client.user.id,
+                        allow:["VIEW_CHANNEL", "SEND_MESSAGES", "READ_MESSAGE_HISTORY", "ATTACH_FILES", "EMBED_LINKS", "MANAGE_MESSAGES", "MANAGE_CHANNELS"]
+                    }
+                ]);
+
+                if(!res){
+                    collected.update({
+                        embeds:[
+                            {
+                                description:`Failed to archive channel.`,
+                                color:"RED"
+                            }
+                        ]
+                    })
+                }
+                if(res){
+                    components[0].components[0].disabled = true;
+                    await interaction.channel.messages.cache.get(starterMessageId)
+                    collected.update({
+                        components,
+                        embeds:[
+                            {
+                                description:`Successfully archived channel.`,
+                                color:"GREEN"
+                            }
+                        ]
+                    })
+                }
+            }
+            return;
+        }
+    })
+  }
+})

--- a/src/buttons/staff_controls.ts
+++ b/src/buttons/staff_controls.ts
@@ -1,0 +1,144 @@
+import { ThreadChannel } from "discord.js";
+import { config } from "../../config";
+import { TicketType } from "../../typings";
+import ButtonCommand from "../classes/ButtonCommand";
+
+export default new ButtonCommand({
+  customId:"staff_controls",
+  checkType:"STARTS_WITH",
+  staffOnly:true,
+  async execute(interaction){
+    let threadStarter = interaction.customId.split("staff_controls_")[1];
+    let threadData = interaction.client.getSupportThreadData(threadStarter);
+    let randomChars = (Math.random() + 1).toString(36).substring(7).toString();
+
+    interaction.reply({
+        content:`**Staff Ticket Controls**`,
+        components:[
+            {
+                type:"ACTION_ROW",
+                components:[
+                    {
+                        "type":"BUTTON",
+                        "style":"SECONDARY",
+                        "customId":`collecter_${randomChars}_switch_ticket_type-${interaction.message?.id}`,
+                        "label":`Toggle Ticket Type`
+                    },
+                    {
+                        "type":"BUTTON",
+                        "style":"SECONDARY",
+                        "customId":`collecter_${randomChars}_toggle_restricted_ticket-${interaction.message?.id}`,
+                        "label":`Toggle Restricted Management to ${interaction.user.tag}`
+                    }
+                ]
+            }
+        ],
+        ephemeral:true
+    })
+
+
+    let collector = interaction.channel.createMessageComponentCollector({
+        componentType:"BUTTON",
+        message:await interaction.fetchReply(),
+        time:300000,
+        filter(button){
+            return button.user.id == interaction.user.id && button.customId.startsWith(`collecter_${randomChars}`)
+        }
+    })
+
+    collector.on("collect", async (collected) => {
+        if(!collected) return;
+        let staffControlsMessageInteraction = collected;
+        let starterMessageId = staffControlsMessageInteraction.customId.split("-")[1];
+        let threadData = interaction.client.getSupportThreadData(threadStarter);
+        
+        // Switch to Public/Private ticket
+        if(staffControlsMessageInteraction.customId.includes("switch_ticket_type")){
+            let newType:TicketType;
+            if(threadData.type == "PUBLIC")
+                newType = "PRIVATE";
+            if(threadData.type == "PRIVATE")
+                newType = "PUBLIC";
+            
+            let res = await interaction.client.updateSupportThread({
+                newType,
+                userId:threadData.userId,
+                threadId:threadData.threadChannelId
+            })
+            if(res === false){
+                staffControlsMessageInteraction.update({
+                    embeds:[
+                        {
+                            description:`Failed to update support thread data. Failed to change ticket type to ${newType == 'PUBLIC' ? "Public" : "Private"}.`,
+                            color:"RED"
+                        }
+                    ]
+                })
+            }
+            if(res == true){
+                staffControlsMessageInteraction.update({
+                    embeds:[
+                        {
+                            description:`Successfully changed ticket type to ${newType == 'PUBLIC' ? "Public" : "Private"}.`,
+                            color:"GREEN"
+                        }
+                    ]
+                })
+                interaction.channel.messages.cache.get(starterMessageId)?.edit({
+                    content:interaction.message.content.replace(newType == "PUBLIC"?":lock: *This is a private ticket, so only staff may reply.*":":unlock: *This is a public ticket, everyone may view and reply to it..*", newType == "PRIVATE"?":lock: *This is a private ticket, so only staff may reply.*":":unlock: *This is a public ticket, everyone may view and reply to it..*")
+                })
+                interaction.channel?.send({
+                    embeds:[
+                        {
+                            description:`${newType == "PUBLIC" ? ":unlock:" : ":lock:"} Ticket has been switched to a ${newType == 'PUBLIC' ? "Public" : "Private"} Ticket.`,
+                            color:newType == "PUBLIC" ? "GREEN" : "RED",
+                            footer:{
+                                iconURL:`https://cdn.discordapp.com/avatars/${interaction.member?.user.id}/${interaction.member?.user.avatar}${interaction.member?.user.avatar.startsWith("a_")?".gif":".png"}`,
+                                text:`${interaction.member?.user.username}#${interaction.member?.user.discriminator}`
+                            }
+                        }
+                    ]
+                })
+            }
+            return;
+        }
+
+        // Lock Ticket Management
+        if(staffControlsMessageInteraction.customId.includes("toggle_restricted_ticket")){
+            let locked: string | undefined;
+            if(typeof threadData.locked == 'undefined')
+                locked = staffControlsMessageInteraction.user?.id;
+            if(typeof threadData.locked == 'string')
+                locked = undefined;
+            console.log("old", threadData.locked)
+            console.log("new", locked)
+            let res = await interaction.client.updateSupportThread({
+                userId:threadData.userId,
+                threadId:threadData.threadChannelId,
+                locked
+            })
+            if(res === false){
+                staffControlsMessageInteraction.update({
+                    embeds:[
+                        {
+                            description:`Failed to update support thread data. Failed to ${typeof locked == 'string'?'restrict':'unrestrict'} ticket management ${typeof locked == 'string'?'to':'from'} ${interaction.user?.tag}.`,
+                            color:"RED"
+                        }
+                    ]
+                })
+            }
+            if(res == true){
+                staffControlsMessageInteraction.update({
+                    embeds:[
+                        {
+                            description:`Successfully ${typeof locked == 'string'?'restricted':'unrestricted'} ticket management ${typeof locked == 'string'?'to':'from'} ${interaction.user?.tag}.`,
+                            color:"GREEN"
+                        }
+                    ]
+                })
+            }
+            return;
+        }
+    })
+  }
+})

--- a/src/classes/ModalCommand.ts
+++ b/src/classes/ModalCommand.ts
@@ -1,0 +1,15 @@
+import { Client } from "discord.js";
+
+class ModalCommand {
+    customId:string
+    staffOnly?:boolean
+    constructor(options:ModalCommand){
+        this.customId = options.customId;
+        this.staffOnly = options.staffOnly;
+        /** Until d.js properly implements Modals, raw payload is used + client second arg */
+        this.execute = options.execute;
+    };
+    /** Until d.js properly implements Modals, raw payload is used + client second arg */
+    execute(interaction:any, client:Client){}
+}
+export default ModalCommand;

--- a/src/commands/closeprompt.ts
+++ b/src/commands/closeprompt.ts
@@ -24,6 +24,11 @@ export default new Command({
                 content:`This command must be sent in the ticket channel`,
                 ephemeral:true
             })
+        if(ticket.locked && ticket.locked != interaction.user.id)
+            return interaction.reply({
+                content:`This ticket's management has been restricted to <@${ticket.locked}>. Please contact them to perform this action.`,
+                ephemeral:true
+            })
         interaction.reply({
             content:`Hey <@${user.id}>,\n\n<@${interaction.user.id}> has requested that this ticket be closed. If you're done with your question, you can close it with the button below. If you are not finished, please let us know so we don't close your ticket for inactivity.`,
             components:[

--- a/src/commands/closeticket.ts
+++ b/src/commands/closeticket.ts
@@ -28,6 +28,11 @@ export default new Command({
                 content:`You can't close a ticket that isn't yours.`,
                 ephemeral:true
             })
+        if(supportThread.locked && supportThread.locked != interaction.user.id)
+            return interaction.reply({
+                content:`This ticket's management has been restricted to <@${supportThread.locked}>. Please contact them to perform this action.`,
+                ephemeral:true
+            })
         if(config.closingTicketsSettings?.ticketsMinimumAge > secondsSinceCreation && !isStaff)
             return interaction.reply({
                 content:`Sorry, this ticket has to remain open for **${remainingTime > 60? Math.floor(remainingTime / 60) : Math.floor(remainingTime)}** more ${remainingTime > 60 ? `minute${Math.floor(remainingTime / 60) == 1 ? `` : `s`}` : `second${Math.floor(remainingTime) <= 1 ? `` : `s`}`} before it can be closed.`,

--- a/src/commands/eta.ts
+++ b/src/commands/eta.ts
@@ -18,9 +18,12 @@ export default new Command({
             "when deepsea becomes a cake",
             "when daniel is banned",
             "when daniel become good programmer",
+            "when daniel gets a good computer",
+            "when daniel plays good games",
+            "when daniel stops making unstable bots",
             "when hax stops playing apex",
             "when hax stops golfing",
-            "when hax finally [explains](https://cdn.discordapp.com/attachments/744457183843844147/934593115623419904/unknown.png)"
+            "when hax finally [explains](https://cdn.discordapp.com/attachments/744457183843844147/934593115623419904/unknown.png) his message from <t:1606257486:R>"
         ]
         const index = Math.floor(Math.random() * messages.length)
         const msg = messages[index]

--- a/src/commands/ticket.ts
+++ b/src/commands/ticket.ts
@@ -6,99 +6,97 @@ export default new Command({
   commandName:"create",
   subCommandGroup:"tickets",
     execute(interaction){
-        // 1-90 char only
-        let supportRoleOnly = interaction.options.data.find(o => o.name == "private")?.value == true  || false;
-        let threadStarter = interaction.member.user.id;
-        let topic = {
-          value:interaction.options.getString("topic")
-        }
-        if(topic.value.length > 90 || topic.value.length < 1)
-          return interaction.reply({
-            content:`Topic must be 1-90 characters`,
-            ephemeral:true
-          })
-        interaction.deferReply({ephemeral:true}).then(() => {
-          let currentThread = interaction.client.getSupportThreadData(threadStarter);
-          if(currentThread?.active || false)
-            return interaction.followUp({
-              content:`You already have a ticket opened. Please use your current ticket or close your current ticket to open a new one.`,
-              components:[
-                {
-                  type:"ACTION_ROW",
-                  components:[
-                    {
-                      type:"BUTTON",
-                      label:"View Current Ticket",
-                      style:"LINK",
-                      url:`https://discord.com/channels/${interaction.guildId}/${currentThread?.threadChannelId}`
-                    },
-                    {
-                      type:"BUTTON",
-                      label:"Close Current Ticket",
-                      style:"DANGER",
-                      customId:`close_ticket_${threadStarter}`
-                    }
-                  ]
-                }
-              ]
-            })
-          interaction.client.createSupportThread({
-            shortDesc:topic.value.toString(), 
-            userId:threadStarter, 
-            privateTicket: supportRoleOnly
-          })
-          .then(channel => {                
-            const questions = [
-              `- Firmware and CFW / Atmosphere / DeepSea version`,
-              `- Do you use hekate or fusee-primary?`,
-              `- If you have an error screen with ID or code, what does it say? A screenshot/picture could be helpful.`,
-              `- What, if anything, have you tried to fix the issue?`,
-              `- Are you coming for support with SDSetup or DeepSea?`
-            ];
-            (interaction.client.channels.cache.get(channel.id) as ThreadChannel).send({
-              "content":`${supportRoleOnly?"\n:lock: *This is a private ticket, so only staff may reply.*":"\n:unlock: *This is a public ticket, everyone may view and reply to it..*"}\n\nHey <@${threadStarter}>, to make it easier for us and others help you with your issue, please tell us a few things about your setup, like:\n\n${questions.join("\n")}`,
-              "components":[
-                {
-                  "type":1,
-                  "components":[
-                    {
-                      "type":2,
-                      "style":2,
-                      "customId":`close_ticket_${threadStarter}`,
-                      "label":"Close Ticket",
-                      "emoji":"🔒"
-                    },
-                    {
-                      "type":"BUTTON",
-                      "style":"SECONDARY",
-                      "customId":`staff_controls_${threadStarter}`,
-                      "label":"Staff Controls",
-                      "emoji":"🛠"
-                    }
-                  ]
-                }
-              ]
-            }).then(r => {
-              r.channel.awaitMessages({
-                max:1,
-                filter(message){
-                  return message.author.id == threadStarter;
-                }
-              }).then(async () => {
-                await interaction.client.updateSupportThread({
-                  threadId:channel.id,
-                  userId:threadStarter
-                });
-                (interaction.client.channels.cache.get(channel.id) as ThreadChannel).send({
-                  "content":`Thanks! <@&${config.supportRoleId}> will be here to support you shortly.\n\n*(Disclaimer: You may not receive an answer instantly. Many of us have lives outside of Discord and will respond whenever we're able to, whenever that is.)*`
-                })
-              })
-              interaction.followUp({
-                content:`Ticket is ready in <#${channel.id}>`,
-                ephemeral:true
-              })
-            })
-          })
+      // 1-90 char only
+      let supportRoleOnly = interaction.options.data.find(o => o.name == "private")?.value == true  || false;
+      let threadStarter = interaction.member.user.id;
+      let topic = {
+        value:interaction.options.getString("topic")
+      }
+      if(topic.value.length > 90 || topic.value.length < 1)
+        return interaction.reply({
+          content:`Topic must be 1-90 characters`,
+          ephemeral:true
         })
+      // @ts-ignore
+      interaction.client.api.interactions(interaction.id)(interaction.token).callback.post({
+        data:{
+          type: 9,
+          data: {
+            components: [
+              {
+                type: 1,
+                components: [
+                  {
+                    type: 4,
+                    custom_id: 'question1',
+                    style: 1,
+                    label: 'Firmware + Atmosphere / DeepSea version',
+                    placeholder: 'FW X.X.X, Atmosphere X.X.X, DeepSea X.X.X',
+                    max_length:50
+                  }
+                ]
+              },
+              {
+                type: 1,
+                components:[
+                  {
+                    type: 4,
+                    custom_id: 'question2',
+                    style: 1,
+                    label: 'Do you use Hekate or Fusee?',
+                    placeholder: 'Hekate / Fusee',
+                    min_length:5,
+                    max_length:50
+                  }
+                ]
+              },
+              {
+                type: 1,
+                components:[
+                  {
+                    type: 4,
+                    custom_id: 'question3',
+                    style: 1,
+                    label: 'Do you have an error code and screen?',
+                    placeholder: 'Error Code 0000-0000 / Screenshot link',
+                    required:false
+                  }
+                ]
+              },
+              {
+                type: 1,
+                components:[
+                  {
+                    type: 4,
+                    custom_id: 'question4',
+                    style: 1,
+                    label: 'Coming for support with SDSetup or DeepSea?',
+                    placeholder: 'SDSetup / DeepSea / Something else',
+                    max_length:50
+                  }
+                ]
+              },
+              {
+                type: 1,
+                components:[
+                  {
+                    type: 4,
+                    custom_id: 'question5',
+                    style: 2,
+                    label: 'Describe your issue and what led up to it',
+                    placeholder: 'Well, I was playing Splatoon 2 until...',
+                    value:topic.value,
+                    min_length:20
+                  }
+                ]
+              }
+            ],
+            title: 'Open Support Ticket',
+            custom_id: 'open_ticket_modal'
+          }
+        }
+      }).then((err) => {
+        console.log(err)
+      });
     }
 })

--- a/src/commands/ticket.ts
+++ b/src/commands/ticket.ts
@@ -71,8 +71,9 @@ export default new Command({
                     {
                       "type":"BUTTON",
                       "style":"SECONDARY",
-                      "customId":`switch_ticket_type_${threadStarter}`,
-                      "label":`Switch to ${supportRoleOnly?"Public":"Private"} Ticket`
+                      "customId":`staff_controls_${threadStarter}`,
+                      "label":"Staff Controls",
+                      "emoji":"🛠"
                     }
                   ]
                 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -253,7 +253,6 @@ process.on('unhandledRejection', error => {
 
 // TEMP: Until d.js properly implements Modals
 client.ws.on("INTERACTION_CREATE", (payload) => {
-	console.log("INTERACTION_CREATE", payload)
 	if(payload.type === 5){
 		let commandName = payload.data?.custom_id;
 
@@ -281,7 +280,6 @@ client.ws.on("INTERACTION_CREATE", (payload) => {
 
 //Code for interactions (Slash Commands, Buttons, CTX comamnds)
 client.on("interactionCreate", interaction => {
-	console.log("interactionCreate", interaction)
 	if(!interaction.channel){
 		console.log(`MISSING INTERACTION.CHANNEL`, `Channel ID: ${interaction.channelId}`, `ID: ${interaction.id}`, `Guild ID: ${interaction.guildId}`, `User ID: ${interaction.member?.user.id}`);
 		return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,11 +72,16 @@ client.createSupportThread = async (options:{shortDesc:string, userId:string, pr
 	return createdChannel;
 }
 
-client.updateSupportThread = async (options:{userId:string, threadId:string, newType?:TicketType, newName?:string}) => {
+client.updateSupportThread = async (options:{userId:string, threadId:string, newType?:TicketType, newName?:string, locked?:string}) => {
 	if(!publicThreads[options.threadId] && !privateThreads[options.threadId])
 		return false;
 	let threadChannel = client.channels.cache.get(options.threadId) as ThreadChannel;
 	let newThreadChannelName:string = threadChannel.name;
+	
+	if(typeof options.locked == 'undefined' && options.locked === undefined || typeof options.locked == 'string'){
+		activeTickets[options.userId].locked = options.locked;
+		saveActiveTicketsData()
+	}
 
 	if(options.newType){
 		activeTickets[options.userId].type = options.newType;

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ client.createSupportThread = async (options:{shortDesc:string, userId:string, pr
 	return createdChannel;
 }
 
-client.updateSupportThread = async (options:{userId:string, threadId:string, newType?:TicketType, newName?:string, locked?:string}) => {
+client.updateSupportThread = async (options:{userId:string, threadId:string, newType?:TicketType, newName?:string, locked?:string, externalChannelId?:string}) => {
 	if(!publicThreads[options.threadId] && !privateThreads[options.threadId])
 		return false;
 	let threadChannel = client.channels.cache.get(options.threadId) as ThreadChannel;
@@ -80,6 +80,11 @@ client.updateSupportThread = async (options:{userId:string, threadId:string, new
 	
 	if(typeof options.locked == 'undefined' && options.locked === undefined || typeof options.locked == 'string'){
 		activeTickets[options.userId].locked = options.locked;
+		saveActiveTicketsData()
+	}
+
+	if(typeof options.externalChannelId == 'undefined' && options.externalChannelId === undefined || typeof options.externalChannelId == 'string'){
+		activeTickets[options.userId].externalChannelId = options.externalChannelId;
 		saveActiveTicketsData()
 	}
 

--- a/src/modals/closed_ticket_feedback.ts
+++ b/src/modals/closed_ticket_feedback.ts
@@ -1,0 +1,43 @@
+import { config } from "../../config";
+import ModalCommand from "../classes/ModalCommand";
+
+export default new ModalCommand({
+    customId:"closed_ticket_feedback",
+    async execute(interaction, client){
+        let feedbackContent:string = interaction.data.components[0]?.components[0]?.value;
+        let supportThreadData = client.getSupportThreadData(interaction.member?.user.id || interaction.user.id);
+        console.log(interaction.data.components)
+        // @ts-ignore
+        client.api.interactions(interaction.id)(interaction.token).callback.post({
+            data:{
+                type:6
+            } 
+        })
+        if(!config.closingTicketsSettings?.incomingFeedbackChannel) return;
+        if(!feedbackContent || feedbackContent?.trim() === '') return;
+        let feedbackChannel = client.channels.cache.get(config.closingTicketsSettings?.incomingFeedbackChannel);
+        let ticketChannel = await client.channels.fetch(interaction.channelId);
+        if(feedbackChannel?.isText() && ticketChannel?.isThread()){
+            feedbackChannel.send({
+                embeds:[
+                    {
+                        title:"Ticket Feedback",
+                        description:feedbackContent || "*No response given*",
+                        fields:[
+                            {
+                                name:`Ticket`,
+                                value:`[${ticketChannel.name}](https://discord.com/channels/${ticketChannel.parentId}/${ticketChannel.id}) (${supportThreadData.threadChannelId})`,
+                                inline:true
+                            },
+                            {
+                                name:`User`,
+                                value:`<@${supportThreadData.userId}> (${supportThreadData.userId})`,
+                                inline:true
+                            }
+                        ]
+                    }
+                ]
+            })
+        }
+    }
+})

--- a/src/modals/closed_ticket_feedback.ts
+++ b/src/modals/closed_ticket_feedback.ts
@@ -16,7 +16,7 @@ export default new ModalCommand({
         if(!config.closingTicketsSettings?.incomingFeedbackChannel) return;
         if(!feedbackContent || feedbackContent?.trim() === '') return;
         let feedbackChannel = client.channels.cache.get(config.closingTicketsSettings?.incomingFeedbackChannel);
-        let ticketChannel = await client.channels.fetch(interaction.channelId);
+        let ticketChannel = await client.channels.fetch(supportThreadData.threadChannelId);
         if(feedbackChannel?.isText() && ticketChannel?.isThread()){
             feedbackChannel.send({
                 embeds:[
@@ -26,7 +26,7 @@ export default new ModalCommand({
                         fields:[
                             {
                                 name:`Ticket`,
-                                value:`[${ticketChannel.name}](https://discord.com/channels/${ticketChannel.parentId}/${ticketChannel.id}) (${supportThreadData.threadChannelId})`,
+                                value:`[${ticketChannel.name}](https://discord.com/channels/${ticketChannel.guildId}/${ticketChannel.id}) (${supportThreadData.threadChannelId})`,
                                 inline:true
                             },
                             {

--- a/src/modals/open_ticket.ts
+++ b/src/modals/open_ticket.ts
@@ -1,0 +1,78 @@
+import { ThreadChannel } from "discord.js";
+import { config } from "../../config";
+import ModalCommand from "../classes/ModalCommand";
+interface PromptedQuestion {
+    question:string
+    response:string
+}
+
+export default new ModalCommand({
+    customId:"open_ticket_modal",
+    staffOnly:false,
+    async execute(interaction, client){
+        console.log("INTERACTION_CREATE_open_ticket_modal", interaction)
+        let threadStarter = interaction.member.user.id;
+        let supportRoleOnly = false;
+        let threadStarterMember = await client.guilds.cache.get(interaction.guild_id).members.fetch(threadStarter);
+
+        client.createSupportThread({
+            shortDesc:`${threadStarterMember.nickname || threadStarterMember.user.tag}`, 
+            userId:threadStarter, 
+            privateTicket:supportRoleOnly
+        })
+        .then(channel => {                
+            const promptedQuestions = [
+            `Firmware + Atmosphere / DeepSea version`,
+            `Do you use Hekate or Fusee-Primary?`,
+            `Do you have an error code/screen?`,
+            `Coming for support with SDSetup or DeepSea?`,
+            `Describe your issue and what led up to it`
+            ];
+            let questionResponses:PromptedQuestion[] = promptedQuestions.map((question, index) => {
+                return {
+                    question,
+                    response:interaction.data.components[index]?.components[0]?.value || "Not provided"
+                }
+            });
+            (client.channels.cache.get(channel.id) as ThreadChannel).send({
+            "content":`${supportRoleOnly?"\n:lock: *This is a private ticket, so only staff may reply.*":"\n:unlock: *This is a public ticket, everyone may view and reply to it..*"}\n\nHey <@${threadStarter}>, <@&${config.supportRoleId}> will be with you as soon as they're able to. Here are the responses you gave in the prompt:\n\n${questionResponses.map(q => `**${q.question}:**\n${q.response}`).join("\n\n")}\n\n*(Disclaimer: You may not receive an answer instantly. Many of us have lives outside of Discord and will respond whenever we're able to, whenever that is.)*`,
+            "components":[
+                {
+                    "type":1,
+                    "components":[
+                        {
+                        "type":2,
+                        "style":2,
+                        "customId":`close_ticket_${threadStarter}`,
+                        "label":"Close Ticket",
+                        "emoji":"🔒"
+                        },
+                        {
+                        "type":"BUTTON",
+                        "style":"SECONDARY",
+                        "customId":`staff_controls_${threadStarter}`,
+                        "label":"Staff Controls",
+                        "emoji":"🛠"
+                        }
+                    ]
+                }
+            ]
+            }).then(async () => {
+                await client.updateSupportThread({
+                    threadId:channel.id,
+                    userId:threadStarter
+                });
+                // @ts-ignore
+                client.api.interactions(interaction.id)(interaction.token).callback.post({
+                    data:{
+                        type:4,
+                        data:{
+                            content:`Ticket is ready in <#${channel.id}>`,
+                            flags:64
+                        }
+                    }
+                })
+            })
+        })
+    }
+})

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2,6 +2,7 @@ import {Message, Collection} from 'discord.js'
 import ButtonCommand from '../src/classes/ButtonCommand'
 import Command from '../src/classes/Command'
 import ContextMenuCommand from '../src/classes/ContextMenuCommand'
+import ModalCommand from '../src/classes/ModalCommand'
 export interface MessageCommand {
   /** Command name */
   name:string,
@@ -89,7 +90,8 @@ declare module 'discord.js' {
       commands: Collection<string, Command>
       messageCommands: Collection<string, MessageCommand>
       buttonCommands: Collection<string, ButtonCommand>
-      ctxCommands: Collection<string, ContextMenuCommand>,
+      ctxCommands: Collection<string, ContextMenuCommand>
+      modalCommands:Collection<string, ModalCommand>
       createSupportThread(options:{
         shortDesc:string,
         userId:string,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -96,7 +96,7 @@ declare module 'discord.js' {
         privateTicket:boolean
       }):Promise<ThreadChannel>
       getSupportThreadData(userId:string):ActiveTicketsData
-      updateSupportThread(options:{userId:string, threadId:string, newType?:TicketType, newName?:string, locked?:string}):Promise<boolean>
+      updateSupportThread(options:{userId:string, threadId:string, newType?:TicketType, newName?:string, locked?:string, externalChannelId?:string}):Promise<boolean>
       closeSupportThread(options:{
         userId:string,
         channelId?:string,
@@ -135,6 +135,8 @@ interface ActiveTicketsData {
   type:TicketType,
   /** Either not present or User ID */
   locked?:string
+  /** Either not present or Channel ID */
+  externalChannelId?:string
 }
 
 interface ActiveTickets {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -61,9 +61,11 @@ export interface Config {
   },
   closingTicketsSettings?:{
     /** Minimum amount of seconds the ticket has to be open before it can be closed */
-    ticketsMinimumAge?:number,
+    ticketsMinimumAge?:number
     /** Message to be sent when ticket is closed */
     closeMessage?:string
+    /** The channel to send incoming feedback from closing tickets */
+    incomingFeedbackChannel?:string
   }
   /** Location of warnings.json */
   warningJsonLocation:string

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -96,7 +96,7 @@ declare module 'discord.js' {
         privateTicket:boolean
       }):Promise<ThreadChannel>
       getSupportThreadData(userId:string):ActiveTicketsData
-      updateSupportThread(options:{userId:string, threadId:string, newType?:TicketType, newName?:string}):Promise<boolean>
+      updateSupportThread(options:{userId:string, threadId:string, newType?:TicketType, newName?:string, locked?:string}):Promise<boolean>
       closeSupportThread(options:{
         userId:string,
         channelId?:string,
@@ -132,7 +132,9 @@ interface ActiveTicketsData {
   userId:string,
   active:boolean,
   createdMs:number,
-  type:TicketType
+  type:TicketType,
+  /** Either not present or User ID */
+  locked?:string
 }
 
 interface ActiveTickets {


### PR DESCRIPTION
## Prerequisites to merge
* Merge #21 

## Features
* Adds support for [Modals](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-modal)

* Adds modal when opening ticket

<img width="470" alt="image" src="https://user-images.githubusercontent.com/46201432/153726042-e061ae35-8710-4ab2-895d-f86c1117de8d.png">

* Show provided information when ticket is opened

<img width="708" alt="image" src="https://user-images.githubusercontent.com/46201432/153726112-8e26ad91-0836-4b7a-8710-c57d38410403.png">

* Show feedback modal upon closing ticket (If done by themself, not by staff & `Config.incomingFeedbackChannel` is present)

<img width="482" alt="image" src="https://user-images.githubusercontent.com/46201432/153726134-f8e3a682-68ea-4ecb-9922-40bbdbdd76e2.png">

* The feedback provided (if any) is sent to the channel set in `Config.incomingFeedbackChannel`

<img width="605" alt="image" src="https://user-images.githubusercontent.com/46201432/153726189-418281b9-1bda-437f-9dd7-00ef797a5e90.png">
